### PR TITLE
Slurm + gpu support and DeepVariant on GPU

### DIFF
--- a/wdl/structs.wdl
+++ b/wdl/structs.wdl
@@ -19,4 +19,7 @@ struct RuntimeAttributes {
 	String zones
 	String queue_arn
 	String container_registry
+	
+	String slurm_partition_default
+	String slurm_partition_gpu
 }

--- a/wdl/tasks/bcftools_stats.wdl
+++ b/wdl/tasks/bcftools_stats.wdl
@@ -45,6 +45,7 @@ task bcftools_stats {
 		maxRetries: runtime_attributes.max_retries
 		awsBatchRetryAttempts: runtime_attributes.max_retries
 		queueArn: runtime_attributes.queue_arn
+		slurm_partition: runtime_attributes.slurm_partition_default
 		zones: runtime_attributes.zones
 	}
 }

--- a/wdl/tasks/glnexus.wdl
+++ b/wdl/tasks/glnexus.wdl
@@ -57,6 +57,7 @@ task glnexus {
 		maxRetries: runtime_attributes.max_retries
 		awsBatchRetryAttempts: runtime_attributes.max_retries
 		queueArn: runtime_attributes.queue_arn
+		slurm_partition: runtime_attributes.slurm_partition_default
 		zones: runtime_attributes.zones
 	}
 }

--- a/wdl/tasks/mosdepth.wdl
+++ b/wdl/tasks/mosdepth.wdl
@@ -43,6 +43,7 @@ task mosdepth {
 		maxRetries: runtime_attributes.max_retries
 		awsBatchRetryAttempts: runtime_attributes.max_retries
 		queueArn: runtime_attributes.queue_arn
+		slurm_partition: runtime_attributes.slurm_partition_default
 		zones: runtime_attributes.zones
 	}
 }

--- a/wdl/tasks/pbsv_call.wdl
+++ b/wdl/tasks/pbsv_call.wdl
@@ -46,6 +46,7 @@ task pbsv_call {
 		maxRetries: runtime_attributes.max_retries
 		awsBatchRetryAttempts: runtime_attributes.max_retries
 		queueArn: runtime_attributes.queue_arn
+		slurm_partition: runtime_attributes.slurm_partition_default
 		zones: runtime_attributes.zones
 	}
 }

--- a/wdl/tasks/pbsv_discover.wdl
+++ b/wdl/tasks/pbsv_discover.wdl
@@ -42,6 +42,7 @@ task pbsv_discover {
 		maxRetries: runtime_attributes.max_retries
 		awsBatchRetryAttempts: runtime_attributes.max_retries
 		queueArn: runtime_attributes.queue_arn
+		slurm_partition: runtime_attributes.slurm_partition_default
 		zones: runtime_attributes.zones
 	}
 }

--- a/wdl/tasks/samtools_fasta.wdl
+++ b/wdl/tasks/samtools_fasta.wdl
@@ -38,6 +38,7 @@ task samtools_fasta {
 		maxRetries: runtime_attributes.max_retries
 		awsBatchRetryAttempts: runtime_attributes.max_retries
 		queueArn: runtime_attributes.queue_arn
+		slurm_partition: runtime_attributes.slurm_partition_default
 		zones: runtime_attributes.zones
 	}
 }

--- a/wdl/tasks/whatshap_haplotag.wdl
+++ b/wdl/tasks/whatshap_haplotag.wdl
@@ -56,6 +56,7 @@ task whatshap_haplotag {
 		maxRetries: runtime_attributes.max_retries
 		awsBatchRetryAttempts: runtime_attributes.max_retries
 		queueArn: runtime_attributes.queue_arn
+		slurm_partition: runtime_attributes.slurm_partition_default
 		zones: runtime_attributes.zones
 	}
 }

--- a/wdl/tasks/whatshap_phase.wdl
+++ b/wdl/tasks/whatshap_phase.wdl
@@ -51,6 +51,7 @@ task whatshap_phase {
 		maxRetries: runtime_attributes.max_retries
 		awsBatchRetryAttempts: runtime_attributes.max_retries
 		queueArn: runtime_attributes.queue_arn
+		slurm_partition: runtime_attributes.slurm_partition_default
 		zones: runtime_attributes.zones
 	}
 }

--- a/wdl/tasks/whatshap_stats.wdl
+++ b/wdl/tasks/whatshap_stats.wdl
@@ -44,6 +44,7 @@ task whatshap_stats {
 		maxRetries: runtime_attributes.max_retries
 		awsBatchRetryAttempts: runtime_attributes.max_retries
 		queueArn: runtime_attributes.queue_arn
+		slurm_partition: runtime_attributes.slurm_partition_default
 		zones: runtime_attributes.zones
 	}
 }

--- a/wdl/tasks/zip_index_vcf.wdl
+++ b/wdl/tasks/zip_index_vcf.wdl
@@ -44,6 +44,7 @@ task zip_index_vcf {
 		maxRetries: runtime_attributes.max_retries
 		awsBatchRetryAttempts: runtime_attributes.max_retries
 		queueArn: runtime_attributes.queue_arn
+		slurm_partition: runtime_attributes.slurm_partition_default
 		zones: runtime_attributes.zones
 	}
 }

--- a/wdl/workflows/deepvariant/inputs.json
+++ b/wdl/workflows/deepvariant/inputs.json
@@ -18,6 +18,8 @@
     "max_retries": "Int",
     "zones": "String",
     "queue_arn": "String",
-    "container_registry": "String"
+    "container_registry": "String",
+    "slurm_partition_default": "String",
+    "slurm_partition_gpu": "String"
   }
 }

--- a/wdl/workflows/phase_vcf/inputs.json
+++ b/wdl/workflows/phase_vcf/inputs.json
@@ -34,7 +34,8 @@
     "max_retries": "Int",
     "zones": "String",
     "queue_arn": "String",
-    "container_registry": "String"
+    "container_registry": "String",
+    "slurm_partition_default": "String"
   }
 }
 

--- a/wdl/workflows/phase_vcf/phase_vcf.wdl
+++ b/wdl/workflows/phase_vcf/phase_vcf.wdl
@@ -122,6 +122,7 @@ task split_vcf {
 		maxRetries: runtime_attributes.max_retries
 		awsBatchRetryAttempts: runtime_attributes.max_retries
 		queueArn: runtime_attributes.queue_arn
+		slurm_partition: runtime_attributes.slurm_partition_default
 		zones: runtime_attributes.zones
 	}
 }
@@ -164,6 +165,7 @@ task bcftools_concat {
 		maxRetries: runtime_attributes.max_retries
 		awsBatchRetryAttempts: runtime_attributes.max_retries
 		queueArn: runtime_attributes.queue_arn
+		slurm_partition: runtime_attributes.slurm_partition_default
 		zones: runtime_attributes.zones
 	}
 }


### PR DESCRIPTION
backend is added as an input

If the backend is slurm and a gpu partition has been defined, then for the deepvariant_call_variants task:
- DeepVariant docker image is changed to gpu version
- runtime.gpu = true
- runtime.cpu is reduced from 64 to 8
- runtime.slurm_partition is set to the gpu partition