### PR TITLE
GLnexus mem can be set by inputs for large cohorts.

### DIFF
--- a/wdl/tasks/glnexus.wdl
+++ b/wdl/tasks/glnexus.wdl
@@ -14,11 +14,14 @@ task glnexus {
 
 		File? regions_bed
 
+		Int? glnexus_mem_gb
+
 		RuntimeAttributes runtime_attributes
 	}
 
 	Int threads = 24
-	Int mem_gbytes = 30
+	Int default_mem_gb = 30
+	Int mem_gb = select_first([glnexus_mem_gb, default_mem_gb])
 	Int disk_size = ceil((size(gvcfs[0], "GB") * length(gvcfs)) * 2 + 100)
 
 	command <<<
@@ -29,7 +32,7 @@ task glnexus {
 
 		glnexus_cli \
 			--threads ~{threads} \
-			--mem-gbytes ~{mem_gbytes} \
+			--mem-gbytes ~{mem_gb} \
 			--dir ~{cohort_id}.~{reference_name}.GLnexus.DB \
 			--config DeepVariant_unfiltered \
 			~{"--bed " + regions_bed} \
@@ -57,7 +60,7 @@ task glnexus {
 	runtime {
 		docker: "ghcr.io/dnanexus-rnd/glnexus:v1.4.1"
 		cpu: threads
-		memory: mem_gbytes + " GB"
+		memory: mem_gb + " GB"
 		disk: disk_size + " GB"
 		disks: "local-disk " + disk_size + " HDD"
 		preemptible: runtime_attributes.preemptible_tries


### PR DESCRIPTION
GLnexus fails in very large families, presumably due to low memory.  Allow users to increase memory in inputs.json without editing WDL.


Modeled after pbsv_call_mem_gb.