### PR TITLE
Fix bcftools stats version call

### DIFF
--- a/wdl/tasks/bcftools_stats.wdl
+++ b/wdl/tasks/bcftools_stats.wdl
@@ -23,7 +23,7 @@ task bcftools_stats {
 	command <<<
 		set -euo pipefail
 
-		bcftools --help
+		bcftools --version
 
 		bcftools stats \
 			--threads ~{threads - 1} \


### PR DESCRIPTION
We were calling --help instead of --version.