### PR TITLE
Use glnexus image in our Quay account.

### DIFF
--- a/wdl/tasks/bcftools_stats.wdl
+++ b/wdl/tasks/bcftools_stats.wdl
@@ -23,7 +23,7 @@ task bcftools_stats {
 	command <<<
 		set -euo pipefail
 
-		bcftools --help
+		bcftools --version
 
 		bcftools stats \
 			--threads ~{threads - 1} \

--- a/wdl/tasks/glnexus.wdl
+++ b/wdl/tasks/glnexus.wdl
@@ -56,7 +56,7 @@ task glnexus {
 	}
 
 	runtime {
-		docker: "~{runtime_attributes.container_registry}/glnexus@sha256:3882cbfba342b1a8cd22955c941fb174480ca468df2027ca267114db3ac1d06d"
+		docker: "~{runtime_attributes.container_registry}/glnexus@sha256:ce6fecf59dddc6089a8100b31c29c1e6ed50a0cf123da9f2bc589ee4b0c69c8e"
 		cpu: threads
 		memory: mem_gb + " GB"
 		disk: disk_size + " GB"

--- a/wdl/tasks/glnexus.wdl
+++ b/wdl/tasks/glnexus.wdl
@@ -56,7 +56,7 @@ task glnexus {
 	}
 
 	runtime {
-		docker: "ghcr.io/dnanexus-rnd/glnexus:v1.4.1"
+		docker: "~{runtime_attributes.container_registry}/glnexus@sha256:3882cbfba342b1a8cd22955c941fb174480ca468df2027ca267114db3ac1d06d"
 		cpu: threads
 		memory: mem_gb + " GB"
 		disk: disk_size + " GB"

--- a/wdl/workflows/deepvariant/deepvariant.wdl
+++ b/wdl/workflows/deepvariant/deepvariant.wdl
@@ -103,7 +103,7 @@ task deepvariant_make_examples {
 	}
 
 	Int task_end_index = task_start_index + tasks_per_shard - 1
-	Int disk_size = ceil(size(aligned_bams[0], "GB") * length(aligned_bams) * 2 + 50)
+	Int disk_size = ceil(size(aligned_bams, "GB") * 2 + 50)
 	Int mem_gb = tasks_per_shard * 4
 
 	command <<<
@@ -174,7 +174,7 @@ task deepvariant_call_variants {
 	}
 
 	Int mem_gb = total_deepvariant_tasks * 4
-	Int disk_size = ceil(size(example_tfrecord_tars[0], "GB") * length(example_tfrecord_tars) * 2 + 100)
+	Int disk_size = ceil(size(example_tfrecord_tars, "GB") * 2 + 100)
 
 	command <<<
 		set -euo pipefail

--- a/wdl/workflows/hiphase/hiphase.wdl
+++ b/wdl/workflows/hiphase/hiphase.wdl
@@ -112,9 +112,12 @@ task run_hiphase {
 		RuntimeAttributes runtime_attributes
 	}
 
+	# to handle single samples with very high depth, we had to increase memory to 3*gpu
+	# to handle cohorts with very high depth, we had to increase memory to 4*gpu
 	Int threads = 16
-	Int mem_gb = threads * 2
+	Int mem_gb = threads * 4
 	Int disk_size = ceil(size(vcfs, "GB") + size(reference, "GB") + size(bams, "GB") * 2 + 20)
+	String haplotags_param = if length(haplotagged_bam_names) > 0 then "--haplotag-file ~{id}.~{refname}.hiphase.haplotags.tsv" else ""
 
 	command <<<
 		set -euo pipefail
@@ -131,7 +134,7 @@ task run_hiphase {
 			--reference ~{reference} \
 			--summary-file ~{id}.~{refname}.hiphase.stats.tsv \
 			--blocks-file ~{id}.~{refname}.hiphase.blocks.tsv \
-			--haplotag-file ~{id}.~{refname}.hiphase.haplotags.tsv \
+			~{haplotags_param} \
 			--global-realignment-cputime 300
 
 		# index phased VCFs
@@ -149,7 +152,7 @@ task run_hiphase {
 		Array[File] haplotagged_bam_indices = glob("*.haplotagged.bam.bai")
 		File hiphase_stats = "~{id}.~{refname}.hiphase.stats.tsv"
 		File hiphase_blocks = "~{id}.~{refname}.hiphase.blocks.tsv"
-		File hiphase_haplotags = "~{id}.~{refname}.hiphase.haplotags.tsv"
+		File hiphase_haplotags = glob("~{id}.~{refname}.hiphase.haplotags.tsv")[0]
 	}
 
 	runtime {

--- a/wdl/workflows/hiphase/hiphase.wdl
+++ b/wdl/workflows/hiphase/hiphase.wdl
@@ -50,7 +50,7 @@ workflow hiphase {
 			phased_vcf_names = phased_vcf_name,
 			phased_vcf_index_names = phased_vcf_index_name,
 			bams = bam,
-			bam_indices = bam_index,	
+			bam_indices = bam_index,
 			haplotagged_bam_names = select_first([haplotagged_bam_name, []]),
 			haplotagged_bam_index_names = select_first([haplotagged_bam_index_name, []]),
 			reference = reference_fasta.data,
@@ -123,16 +123,16 @@ task run_hiphase {
 
 		# phase VCFs and haplotag BAM
 		hiphase --threads ~{threads} \
-		~{sep=" " prefix("--sample-name ", sample_ids)} \
-		~{sep=" " prefix("--vcf ", vcfs)} \
-		~{sep=" " prefix("--output-vcf ", phased_vcf_names)} \
-		~{sep=" " prefix("--bam ", bams)} \
-		~{true="--output-bam " false="" length(haplotagged_bam_names) > 0} ~{sep=" --output-bam " haplotagged_bam_names} \
-		--reference ~{reference} \
-		--summary-file ~{id}.~{refname}.hiphase.stats.tsv \
-		--blocks-file ~{id}.~{refname}.hiphase.blocks.tsv \
-		--haplotag-file ~{id}.~{refname}.hiphase.haplotags.tsv \
-		--global-realignment-cputime 300
+			~{sep=" " prefix("--sample-name ", sample_ids)} \
+			~{sep=" " prefix("--vcf ", vcfs)} \
+			~{sep=" " prefix("--output-vcf ", phased_vcf_names)} \
+			~{sep=" " prefix("--bam ", bams)} \
+			~{true="--output-bam " false="" length(haplotagged_bam_names) > 0} ~{sep=" --output-bam " haplotagged_bam_names} \
+			--reference ~{reference} \
+			--summary-file ~{id}.~{refname}.hiphase.stats.tsv \
+			--blocks-file ~{id}.~{refname}.hiphase.blocks.tsv \
+			--haplotag-file ~{id}.~{refname}.hiphase.haplotags.tsv \
+			--global-realignment-cputime 300
 
 		# index phased VCFs
 		bcftools --version

--- a/wdl/workflows/phase_vcf/phase_vcf.wdl
+++ b/wdl/workflows/phase_vcf/phase_vcf.wdl
@@ -142,7 +142,7 @@ task bcftools_concat {
 	}
 
 	Int threads = 2
-	Int disk_size = ceil(size(vcfs[0], "GB") * length(vcfs) * 2 + 20)
+	Int disk_size = ceil(size(vcfs, "GB") * 2 + 20)
 
 	command <<<
 		set -euo pipefail


### PR DESCRIPTION
Cromwell has a problem hashing images in ghcr.io.  This means that call-caching does not work for GLnexus tasks.  GLnexus is fast, but downstream tasks like HiPhase can be much slower.

Pushed glnexus:1.4.1 to Quay.

https://github.com/broadinstitute/cromwell/issues/6827

Still need to update wdl-dockerfiles to automate pushing this image to a container repo.