### PR TITLE
Use grep to filter svsigs to filter svsigs within region.

### DIFF
--- a/wdl/tasks/concat_vcf.wdl
+++ b/wdl/tasks/concat_vcf.wdl
@@ -7,6 +7,7 @@ import "../structs.wdl"
 task concat_vcf {
 	input {
 		Array[File] vcfs
+		Array[File] vcf_indices
 
 		String output_vcf_name
 
@@ -24,17 +25,16 @@ task concat_vcf {
 		bcftools concat \
 			--allow-overlaps \
 			--threads ~{threads - 1} \
-			--output-type b \
-			~{sep=' ' vcfs} \
-		| bcftools sort \
-			--max-mem 4G \
 			--output-type z \
 			--output ~{output_vcf_name} \
-			/dev/stdin
+			~{sep=' ' vcfs}
+
+		bcftools index --tbi ~{output_vcf_name}
 	>>>
 
 	output {
 		File concatenated_vcf = "~{output_vcf_name}"
+		File concatenated_vcf_index = "~{output_vcf_name}.tbi"
 	}
 
 	runtime {

--- a/wdl/tasks/concat_vcf.wdl
+++ b/wdl/tasks/concat_vcf.wdl
@@ -22,6 +22,7 @@ task concat_vcf {
 		bcftools --version
 
 		bcftools concat \
+			--allow-overlaps \
 			--threads ~{threads - 1} \
 			--output-type b \
 			~{sep=' ' vcfs} \

--- a/wdl/tasks/concat_vcf.wdl
+++ b/wdl/tasks/concat_vcf.wdl
@@ -1,0 +1,51 @@
+version 1.0
+
+# Concatenate and sort VCFs
+
+import "../structs.wdl"
+
+task concat_vcf {
+	input {
+		Array[File] vcfs
+
+		String output_vcf_name
+
+		RuntimeAttributes runtime_attributes
+	}
+
+	Int threads = 4
+	Int disk_size = ceil(size(vcfs, "GB") * 2 + 20)
+	
+	command <<<
+		set -euo pipefail
+
+		bcftools --version
+
+		bcftools concat \
+			--threads ~{threads - 1} \
+			--output-type b \
+			~{sep=' ' vcfs} \
+		| bcftools sort \
+			--max-mem 4G \
+			--output-type z \
+			--output ~{output_vcf_name} \
+			/dev/stdin
+	>>>
+
+	output {
+		File concatenated_vcf = "~{output_vcf_name}"
+	}
+
+	runtime {
+		docker: "~{runtime_attributes.container_registry}/bcftools@sha256:36d91d5710397b6d836ff87dd2a924cd02fdf2ea73607f303a8544fbac2e691f"
+		cpu: threads
+		memory: "8 GB"
+		disk: disk_size + " GB"
+		disks: "local-disk " + disk_size + " HDD"
+		preemptible: runtime_attributes.preemptible_tries
+		maxRetries: runtime_attributes.max_retries
+		awsBatchRetryAttempts: runtime_attributes.max_retries
+		queueArn: runtime_attributes.queue_arn
+		zones: runtime_attributes.zones
+	}
+}

--- a/wdl/tasks/pbsv_call.wdl
+++ b/wdl/tasks/pbsv_call.wdl
@@ -35,7 +35,7 @@ task pbsv_call {
 		# Build a pattern to match; we want headers (e.g., '^#') and signature
 		#   records where third column matches the chromosome (e.g., '^.\t.\tchr1\t').
 		pattern=$(echo ~{sep=" " regions} \
-			| sed 's/^/^.\\t.\\t/; s/ /\\t\|^.\\t.\\t/; s/$/\\t/' \
+			| sed 's/^/^.\\t.\\t/; s/ /\\t\|^.\\t.\\t/g; s/$/\\t/' \
 			| echo "^#|""$(</dev/stdin)")
 
 		for svsig in ~{sep=" " svsigs}; do
@@ -56,10 +56,19 @@ task pbsv_call {
 			~{reference} \
 			svsigs.fofn \
 			"~{sample_id}.~{reference_name}.pbsv.vcf"
+
+		bgzip --version
+		
+		bgzip "~{sample_id}.~{reference_name}.pbsv.vcf"
+
+		tabix --version
+
+		tabix -p vcf "~{sample_id}.~{reference_name}.pbsv.vcf.gz"
 	>>>
 
 	output {
-		File pbsv_vcf = "~{sample_id}.~{reference_name}.pbsv.vcf"
+		File pbsv_vcf = "~{sample_id}.~{reference_name}.pbsv.vcf.gz"
+		File pbsv_vcf_index = "~{sample_id}.~{reference_name}.pbsv.vcf.gz.tbi"
 	}
 
 	runtime {

--- a/wdl/tasks/pbsv_call.wdl
+++ b/wdl/tasks/pbsv_call.wdl
@@ -31,11 +31,11 @@ task pbsv_call {
 		#   if an svsig.gz file doesn't contain any signatures in the region, then
 		#   pbsv crashes. To avoid this, filter the svsig.gz files to only contain
 		#   signatures in the regions.
-		# this is brittle and likely to break if pbsv discover changes output format.
-		# build a pattern to match; we want headers (e.g., '^#') and signature
-		#   records where third column matches the chromosome (e.g., '^.\t.\tCHR\t')
+		# This is brittle and likely to break if pbsv discover changes output format.
+		# Build a pattern to match; we want headers (e.g., '^#') and signature
+		#   records where third column matches the chromosome (e.g., '^.\t.\tchr1\t').
 		pattern=$(echo ~{sep=" " regions} \
-			| sed 's!^!^.\\t.\\t!;s! !\\t\|^.\\t.\\t!;s!$!\\t!' \
+			| sed 's/^/^.\\t.\\t/; s/ /\\t\|^.\\t.\\t/; s/$/\\t/' \
 			| echo "^#|""$(</dev/stdin)")
 
 		for svsig in ~{sep=" " svsigs}; do

--- a/wdl/tasks/pbsv_call.wdl
+++ b/wdl/tasks/pbsv_call.wdl
@@ -47,7 +47,7 @@ task pbsv_call {
 					&& echo "${svsig_basename}.regions.svsig.gz" >> svsigs.fofn
 			done
 		else
-			echo ~{sep="\n" svsigs} > svsigs.fofn
+			cp ~{write_lines(svsigs)} svsigs.fofn
 		fi
 
 		pbsv --version

--- a/wdl/tasks/pbsv_call.wdl
+++ b/wdl/tasks/pbsv_call.wdl
@@ -59,7 +59,7 @@ task pbsv_call {
 	>>>
 
 	output {
-		Array[File] pbsv_vcf = glob("~{sample_id}.~{reference_name}.pbsv.vcf")
+		File pbsv_vcf = "~{sample_id}.~{reference_name}.pbsv.vcf"
 	}
 
 	runtime {

--- a/wdl/tasks/pbsv_discover.wdl
+++ b/wdl/tasks/pbsv_discover.wdl
@@ -35,7 +35,7 @@ task pbsv_discover {
 	}
 
 	runtime {
-		docker: "~{runtime_attributes.container_registry}/pbsv@sha256:ac0994c6098e7b539f44d4df74472b9cc921e45e424af22941ba9340f4bcec0f"
+		docker: "~{runtime_attributes.container_registry}/pbsv@sha256:d78ee6deb92949bdfde98d3e48dab1d871c177d48d8c87c73d12c45bdda43446"
 		cpu: 2
 		memory: "8 GB"
 		disk: disk_size + " GB"


### PR DESCRIPTION
**This PR is not a PR of honor.  No highly esteemed commit is pushed here.  Nothing valued is here.**

`pbsv call` has a mechanism for indexed access to an arbitrary region.  However, if there are no sigs for this region in the svsig files, there is a fatal error:

```
pbsv call ERROR: Could not load index
```

To work around this, I use grep to create filtered svsig files with the header and records from given regions.  Given that the svsig format is not published or fixed, this is brittle.  I wouldn't recommend this except that breaking `pbsv call` into chunks will likely save ~20% of wall-time for the typical trio.

**What is here was dangerous and repulsive to us. This message is a warning about danger.**