### PR TITLE
Hotfix/deepvariant 1.6

### DIFF
--- a/wdl/workflows/deepvariant/deepvariant.wdl
+++ b/wdl/workflows/deepvariant/deepvariant.wdl
@@ -185,8 +185,8 @@ task deepvariant_call_variants {
 
 		if ~{defined(custom_deepvariant_model_tar)}; then
 			mkdir -p /opt/models/custom
-			tar --no-same-owner -zxvf ~{custom_deepvariant_model_tar} -C /opt/models/custom
-			DEEPVARIANT_MODEL="/opt/models/custom"
+			tar --no-same-owner -zxvf ~{custom_deepvariant_model_tar} -C ./custom_deepvariant_model
+			DEEPVARIANT_MODEL="./custom_deepvariant_model"
 		else
 			DEEPVARIANT_MODEL="/opt/models/pacbio"
 		fi

--- a/wdl/workflows/deepvariant/deepvariant.wdl
+++ b/wdl/workflows/deepvariant/deepvariant.wdl
@@ -137,8 +137,10 @@ task deepvariant_make_examples {
 				--gvcf nonvariant_site_tfrecords/~{sample_id}.gvcf.tfrecord@~{total_deepvariant_tasks}.gz \
 				--task {}
 
-		tar -zcvf ~{sample_id}.~{task_start_index}.example_tfrecords.tar.gz example_tfrecords
-		tar -zcvf ~{sample_id}.~{task_start_index}.nonvariant_site_tfrecords.tar.gz nonvariant_site_tfrecords
+		tar -zcvf ~{sample_id}.~{task_start_index}.example_tfrecords.tar.gz example_tfrecords \
+			&& rm -rf example_tfrecords
+		tar -zcvf ~{sample_id}.~{task_start_index}.nonvariant_site_tfrecords.tar.gz nonvariant_site_tfrecords \
+			&& rm -rf nonvariant_site_tfrecords
 	>>>
 
 	output {
@@ -199,7 +201,10 @@ task deepvariant_call_variants {
 			--examples "example_tfrecords/~{sample_id}.examples.tfrecord@~{total_deepvariant_tasks}.gz" \
 			--checkpoint "${DEEPVARIANT_MODEL}"
 
-		tar -zcvf ~{sample_id}.~{reference_name}.call_variants_output.tar.gz ~{sample_id}.~{reference_name}.call_variants_output*.tfrecord.gz
+		tar -zcvf ~{sample_id}.~{reference_name}.call_variants_output.tar.gz ~{sample_id}.~{reference_name}.call_variants_output*.tfrecord.gz \
+			&& rm ~{sample_id}.~{reference_name}.call_variants_output*.tfrecord.gz \
+			&& rm -rf example_tfrecords \
+			&& rm -rf ./custom_deepvariant_model
 	>>>
 
 	output {
@@ -257,6 +262,9 @@ task deepvariant_postprocess_variants {
 			--outfile ~{sample_id}.~{reference_name}.deepvariant.vcf.gz \
 			--nonvariant_site_tfrecord_path "nonvariant_site_tfrecords/~{sample_id}.gvcf.tfrecord@~{total_deepvariant_tasks}.gz" \
 			--gvcf_outfile ~{sample_id}.~{reference_name}.deepvariant.g.vcf.gz
+
+		rm -rf nonvariant_site_tfrecords \
+			&& rm ~{sample_id}.~{reference_name}.call_variants_output*.tfrecord.gz
 	>>>
 
 	output {


### PR DESCRIPTION
I was a little too hasty to merge the previous DeepVariant updates.

- The logic for custom models didn't work, because it attempted to decompress the files into a read-only filesystem.  Now it decompresses into the current folder.
- While I'm taking the time to look at this, I've added steps to remove some intermediate files that cause a lot of unnecessary bloat.  The final outputs of make_examples and call_variants are tarballs, but we kept the original files around, so everything was duplicated.  I added steps to remove the original files after the tarballs are successfully created, and to remove the untarred files after the downstream tasks complete.